### PR TITLE
Update html-routes.js

### DIFF
--- a/Develop/routes/html-routes.js
+++ b/Develop/routes/html-routes.js
@@ -9,8 +9,4 @@ module.exports = function (app) {
         res.sendFile(path.join(__dirname,"/../public/stats.html"))
     });
 
-    app.use((req,res)=>{
-        res.sendFile(path.join(__dirname,"/../public/index.html"));
-        //console.log(path.join(__dirname,"./frontend/index.html"));
-    });
-};
+   


### PR DESCRIPTION
Remove these lines:
 app.use((req,res)=>{
        res.sendFile(path.join(__dirname,"/../public/index.html"));
        //console.log(path.join(__dirname,"./frontend/index.html"));
    });
Because of these lines of code your api-routes were never getting hit and therefore not throwing errors. In its current state any request to the server returns the index.html. Removing those lines should do the trick.